### PR TITLE
Fix | 대시보드 상세 조회 및 대시보드 삭제 로직 수정

### DIFF
--- a/src/main/java/com/dashboardTemplate/dashboardTemplate/domain/dashboard/repository/AggregatedDataRepository.java
+++ b/src/main/java/com/dashboardTemplate/dashboardTemplate/domain/dashboard/repository/AggregatedDataRepository.java
@@ -4,12 +4,13 @@ import com.dashboardTemplate.dashboardTemplate.domain.dashboard.entity.Aggregate
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AggregatedDataRepository extends JpaRepository<AggregatedData, Integer> {
 
-    Optional<AggregatedData> findByDashboardId(String dashboardId);
+    List<AggregatedData> findByDashboardId(String dashboardId);
 
     void deleteByDashboardId(String dashboardId);
 }

--- a/src/main/java/com/dashboardTemplate/dashboardTemplate/domain/dashboard/repository/GroupDataRepository.java
+++ b/src/main/java/com/dashboardTemplate/dashboardTemplate/domain/dashboard/repository/GroupDataRepository.java
@@ -4,12 +4,13 @@ import com.dashboardTemplate.dashboardTemplate.domain.dashboard.entity.GroupData
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface GroupDataRepository extends JpaRepository<GroupData, Integer> {
 
-    Optional<GroupData> findByDashboardId(String dashboardId);
+    List<GroupData> findByDashboardId(String dashboardId);
 
     void deleteByDashboardId(String dashboardId);
 }


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
 fix/checkDashboardDetails-> master

## 변경 사항
 대시보드 상세 조회 시, dashboardDetailInfo의  groupData와 aggregatedData를 리스트로 반환하도록 수정하였습니다.
 대시보드 삭제 시, dashboardId로 조회한 값을 리스트로 받아 삭제하도록 수정하였습니다.

## 테스트 결과
<img width="504" height="584" alt="image" src="https://github.com/user-attachments/assets/c564dfbe-4ab3-4dcf-9ce8-9444621d739b" />

## ETC
